### PR TITLE
feat: establish financial domain model

### DIFF
--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -60,4 +60,3 @@ export interface FireSettings {
   monthlyContributionAssumption: NonNegativeYen;
   withdrawalRate?: number;
 }
-

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1,0 +1,63 @@
+/** Integer Japanese yen. Values may be signed when representing a calculated delta. */
+export type Yen = number;
+
+/** Integer Japanese yen that cannot be negative. */
+export type NonNegativeYen = Yen;
+
+/** A calendar month in the canonical YYYY-MM representation. */
+export type MonthKey = string;
+
+export const accountCategories = [
+  "cash",
+  "nisa_tsumitate",
+  "nisa_growth",
+  "taxable",
+  "other",
+] as const;
+
+export type AccountCategory = (typeof accountCategories)[number];
+
+export interface AssetAccount {
+  id: string;
+  name: string;
+  category: AccountCategory;
+  isActive: boolean;
+  sortOrder: number;
+}
+
+/**
+ * Cash-flow information for one calendar month.
+ *
+ * Investment contribution is intentionally separate from expenses. It is an
+ * allocation of money, not a consumption expense.
+ */
+export interface MonthlyCashFlowRecord {
+  id: string;
+  month: MonthKey;
+  income: NonNegativeYen;
+  expenses: NonNegativeYen;
+  investmentContribution: NonNegativeYen;
+  note?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A month-end balance for one account; it is not a cash-flow transaction. */
+export interface AccountBalanceSnapshot {
+  id: string;
+  month: MonthKey;
+  accountId: string;
+  balance: NonNegativeYen;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Assumptions are explicit so that no universal FIRE rule is hard-coded. */
+export interface FireSettings {
+  targetAmount: NonNegativeYen;
+  annualReturnRate: number;
+  annualInflationRate: number;
+  monthlyContributionAssumption: NonNegativeYen;
+  withdrawalRate?: number;
+}
+

--- a/src/domain/validation.ts
+++ b/src/domain/validation.ts
@@ -30,4 +30,3 @@ export function isAccountCategory(value: unknown): value is AccountCategory {
 export function isIsoDateTime(value: unknown): value is string {
   return typeof value === "string" && !Number.isNaN(Date.parse(value));
 }
-

--- a/src/domain/validation.ts
+++ b/src/domain/validation.ts
@@ -1,0 +1,33 @@
+import {
+  accountCategories,
+  type AccountCategory,
+  type MonthKey,
+  type NonNegativeYen,
+  type Yen,
+} from "./models";
+
+export function isYen(value: unknown): value is Yen {
+  return typeof value === "number" && Number.isSafeInteger(value);
+}
+
+export function isNonNegativeYen(value: unknown): value is NonNegativeYen {
+  return isYen(value) && value >= 0;
+}
+
+export function isMonthKey(value: unknown): value is MonthKey {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const match = /^(\d{4,})-(0[1-9]|1[0-2])$/.exec(value);
+  return match !== null && Number(match[1]) > 0;
+}
+
+export function isAccountCategory(value: unknown): value is AccountCategory {
+  return typeof value === "string" && accountCategories.some((category) => category === value);
+}
+
+export function isIsoDateTime(value: unknown): value is string {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+

--- a/tests/unit/domain/validation.test.ts
+++ b/tests/unit/domain/validation.test.ts
@@ -55,4 +55,3 @@ describe("other domain primitives", () => {
     expect(isIsoDateTime("not-a-date")).toBe(false);
   });
 });
-

--- a/tests/unit/domain/validation.test.ts
+++ b/tests/unit/domain/validation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAccountCategory,
+  isIsoDateTime,
+  isMonthKey,
+  isNonNegativeYen,
+  isYen,
+} from "../../../src/domain/validation";
+
+describe("yen validation", () => {
+  it("accepts safe integer yen, including calculated negative deltas", () => {
+    expect(isYen(0)).toBe(true);
+    expect(isYen(123_456)).toBe(true);
+    expect(isYen(-5_000)).toBe(true);
+  });
+
+  it("rejects fractional and unsafe amounts", () => {
+    expect(isYen(100.5)).toBe(false);
+    expect(isYen(Number.MAX_SAFE_INTEGER + 1)).toBe(false);
+    expect(isYen("100")).toBe(false);
+  });
+
+  it("requires recorded balances and contributions to be non-negative", () => {
+    expect(isNonNegativeYen(0)).toBe(true);
+    expect(isNonNegativeYen(1)).toBe(true);
+    expect(isNonNegativeYen(-1)).toBe(false);
+  });
+});
+
+describe("month key validation", () => {
+  it("accepts a canonical calendar month", () => {
+    expect(isMonthKey("2026-09")).toBe(true);
+  });
+
+  it("rejects non-canonical or impossible months", () => {
+    expect(isMonthKey("2026-9")).toBe(false);
+    expect(isMonthKey("2026-00")).toBe(false);
+    expect(isMonthKey("2026-13")).toBe(false);
+    expect(isMonthKey("0000-01")).toBe(false);
+  });
+});
+
+describe("other domain primitives", () => {
+  it("supports only the initial extensible account categories", () => {
+    expect(isAccountCategory("cash")).toBe(true);
+    expect(isAccountCategory("nisa_tsumitate")).toBe(true);
+    expect(isAccountCategory("nisa_growth")).toBe(true);
+    expect(isAccountCategory("taxable")).toBe(true);
+    expect(isAccountCategory("other")).toBe(true);
+    expect(isAccountCategory("brokerage")).toBe(false);
+  });
+
+  it("accepts valid ISO-compatible timestamps", () => {
+    expect(isIsoDateTime("2026-09-04T00:00:00.000Z")).toBe(true);
+    expect(isIsoDateTime("not-a-date")).toBe(false);
+  });
+});
+


### PR DESCRIPTION
Closes #1

## 변경 내용

- 정수 일본 엔 금액과 월 키 검증 규칙을 추가했습니다.
- 확장 가능한 계좌 분류, 월별 현금흐름 기록, 계좌별 월말 잔액 스냅샷, FIRE 설정 모델을 정의했습니다.
- 현금흐름과 자산 잔액을 별도 모델로 유지했습니다.
- 도메인 계층은 React, IndexedDB, 네트워크에 의존하지 않습니다.

## 검증

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 8 tests passed
- `npm run build`
- `npm run test:e2e` — Chromium 1 test passed

## 범위 밖

저장소 구현, 입력 화면, 대시보드, JSON import/export, FIRE 예측 계산은 포함하지 않았습니다.